### PR TITLE
Suggested Edit: Update example for grid-auto-columns and grid-auto-rows properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ using `grid-auto-columns` and `grid-auto-rows`. These properties can take in
 a length, or a unit such as `fr`, and apply this as the default for all cells
 in a grid. So, for instance, if we added `grid-auto-rows: 50px;` to our
 `.grid-container` class, our grid will shrink a bit, as each row will now be
-exactly 50 pixels tall.
+exactly 50 pixels tall. However, this will only work if we remove the `grid-template-rows` property; the same is true for `grid-auto-columns` and `grid-template-columns`. (If you try this, be sure to add the `grid-template-rows` and `grid-template-columns` settings back in, before moving on to the next example.)
 
 #### `grid-gap`
 


### PR DESCRIPTION
Note: I am aware that you can set grid-auto-rows and grid-template-rows at the same time.
However, the effects won't be seen unless the elements go outside of the grid area.
I would have added this, but the idea of elements going outside of the grid area isn't mentioned in the README until later.